### PR TITLE
Return the messages channel

### DIFF
--- a/src/khroma/runtime.cljs
+++ b/src/khroma/runtime.cljs
@@ -1,7 +1,6 @@
 (ns khroma.runtime
   (:require 
             [khroma.log :as log]
-            
             [cljs.core.async :as async]
             [cljs.core.async.impl.protocols :as p])
   
@@ -79,7 +78,8 @@
     (.addListener js/chrome.runtime.onMessage 
       (fn [message sender reply-fn]
         (go
-          (>! ch (message-event message sender reply-fn)))))))
+          (>! ch (message-event message sender reply-fn)))))
+    ch))
 
 (defn send-message [message & options]
   (let [{:keys [extensionId options responseCallback]} (apply hash-map options)]


### PR DESCRIPTION
Hi,

Khroma looks like a really promising library. 

From what I can see from the code and the example in the README runtime/messages needs to return the channel it creates or the calling code will never get access to the messages captured in that function.
